### PR TITLE
Use a fork channel for Counter and Lock protocols

### DIFF
--- a/src/main/asciidoc/java/index.adoc
+++ b/src/main/asciidoc/java/index.adoc
@@ -246,6 +246,7 @@ Then override the default JGroups config so that `KUBE_PING` becomes the discove
   <MFC max_credits="2m"
 *        min_threshold="0.40"
 *   />
+  <FRAG3/>
 </config>
 ----
 

--- a/src/main/asciidoc/java/index.adoc
+++ b/src/main/asciidoc/java/index.adoc
@@ -156,14 +156,6 @@ Notice that the custom Infinispan instance need to be configured with:
 </cache-container>
 ----
 
-Besides, the JGroups channel stack must include the counter and lock protocols (at or near the top of the stack):
-
-[source, xml]
-----
-<CENTRAL_LOCK use_thread_id_for_lock_owner="false" bypass_bundling="true"/>
-<COUNTER bypass_bundling="true"/>
-----
-
 == Configuring for Openshift 3
 
 In order to run a Vert.x cluster on Openshift 3, a few configuration and dependencies changes are needed.
@@ -254,9 +246,6 @@ Then override the default JGroups config so that `KUBE_PING` becomes the discove
   <MFC max_credits="2m"
 *        min_threshold="0.40"
 *   />
-  <FRAG2/>
-  <CENTRAL_LOCK use_thread_id_for_lock_owner="false" bypass_bundling="true"/>
-  <COUNTER bypass_bundling="true"/>
 </config>
 ----
 

--- a/src/main/java/io/vertx/ext/cluster/infinispan/InfinispanClusterManager.java
+++ b/src/main/java/io/vertx/ext/cluster/infinispan/InfinispanClusterManager.java
@@ -47,8 +47,13 @@ import org.infinispan.notifications.cachemanagerlistener.event.MergeEvent;
 import org.infinispan.notifications.cachemanagerlistener.event.ViewChangedEvent;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.remoting.transport.jgroups.JGroupsTransport;
+import org.jgroups.JChannel;
 import org.jgroups.blocks.atomic.CounterService;
 import org.jgroups.blocks.locking.LockService;
+import org.jgroups.fork.ForkChannel;
+import org.jgroups.protocols.CENTRAL_LOCK;
+import org.jgroups.protocols.COUNTER;
+import org.jgroups.stack.Protocol;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -62,6 +67,7 @@ import java.util.WeakHashMap;
 import java.util.concurrent.TimeUnit;
 
 import static java.util.stream.Collectors.*;
+import static org.jgroups.stack.ProtocolStack.Position.*;
 
 /**
  * @author Thomas Segismont
@@ -80,6 +86,7 @@ public class InfinispanClusterManager implements ClusterManager {
   private ClusterViewListener viewListener;
   // Guarded by this
   private Set<InfinispanAsyncMultiMap> multimaps = Collections.newSetFromMap(new WeakHashMap<>(1));
+  private ForkChannel forkChannel;
 
   public InfinispanClusterManager() {
     this.configPath = System.getProperty("vertx.infinispan.config", "infinispan.xml");
@@ -189,14 +196,29 @@ public class InfinispanClusterManager implements ClusterManager {
           cacheManager = new DefaultCacheManager(builderHolder, true);
         } catch (IOException e) {
           future.fail(e);
+          return;
         }
       }
       viewListener = new ClusterViewListener();
       cacheManager.addListener(viewListener);
       JGroupsTransport transport = (JGroupsTransport) cacheManager.getTransport();
-      counterService = new CounterService(transport.getChannel());
-      lockService = new LockService(transport.getChannel());
-      future.complete();
+      JChannel channel = transport.getChannel();
+      CENTRAL_LOCK centralLock = new CENTRAL_LOCK();
+      centralLock.setValue("use_thread_id_for_lock_owner", Boolean.FALSE);
+      centralLock.setBypassBundling(true);
+      COUNTER counter = new COUNTER();
+      counter.setBypassBundling(true);
+      Protocol[] protocols = new Protocol[]{centralLock, counter};
+      Class<? extends Protocol> topProtocol = channel.getProtocolStack().getTopProtocol().getClass();
+      try {
+        forkChannel = new ForkChannel(channel, "vertx-infinispan-stack", "vertx-infinispan-channel", true, ABOVE, topProtocol, protocols);
+        forkChannel.connect("ignored");
+        counterService = new CounterService(forkChannel);
+        lockService = new LockService(forkChannel);
+        future.complete();
+      } catch (Exception e) {
+        future.fail(e);
+      }
     }, false, resultHandler);
   }
 
@@ -208,6 +230,7 @@ public class InfinispanClusterManager implements ClusterManager {
         return;
       }
       active = false;
+      forkChannel.close();
       cacheManager.removeListener(viewListener);
       if (configPath != null) {
         cacheManager.stop();

--- a/src/main/java/io/vertx/ext/cluster/infinispan/package-info.java
+++ b/src/main/java/io/vertx/ext/cluster/infinispan/package-info.java
@@ -235,6 +235,7 @@
  *   <MFC max_credits="2m"
  *        min_threshold="0.40"
  *   />
+ *   <FRAG3/>
  * </config>
  * ----
  *

--- a/src/main/java/io/vertx/ext/cluster/infinispan/package-info.java
+++ b/src/main/java/io/vertx/ext/cluster/infinispan/package-info.java
@@ -145,14 +145,6 @@
  * </cache-container>
  * ----
  *
- * Besides, the JGroups channel stack must include the counter and lock protocols (at or near the top of the stack):
- *
- * [source, xml]
- * ----
- * <CENTRAL_LOCK use_thread_id_for_lock_owner="false" bypass_bundling="true"/>
- * <COUNTER bypass_bundling="true"/>
- * ----
- *
  * == Configuring for Openshift 3
  *
  * In order to run a Vert.x cluster on Openshift 3, a few configuration and dependencies changes are needed.
@@ -243,9 +235,6 @@
  *   <MFC max_credits="2m"
  *        min_threshold="0.40"
  *   />
- *   <FRAG2/>
- *   <CENTRAL_LOCK use_thread_id_for_lock_owner="false" bypass_bundling="true"/>
- *   <COUNTER bypass_bundling="true"/>
  * </config>
  * ----
  *

--- a/src/main/resources/jgroups.xml
+++ b/src/main/resources/jgroups.xml
@@ -67,6 +67,4 @@
   <MFC max_credits="2m"
        min_threshold="0.40"
   />
-  <CENTRAL_LOCK use_thread_id_for_lock_owner="false" bypass_bundling="true"/>
-  <COUNTER bypass_bundling="true"/>
 </config>

--- a/src/main/resources/jgroups.xml
+++ b/src/main/resources/jgroups.xml
@@ -67,4 +67,5 @@
   <MFC max_credits="2m"
        min_threshold="0.40"
   />
+  <FRAG3/>
 </config>

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2017 Red Hat, Inc.
+  ~
+  ~ Red Hat licenses this file to you under the Apache License, version 2.0
+  ~ (the "License"); you may not use this file except in compliance with the
+  ~ License.  You may obtain a copy of the License at:
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+  ~ License for the specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<configuration debug="false">
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+  <root level="INFO">
+    <appender-ref ref="STDOUT"/>
+  </root>
+</configuration>


### PR DESCRIPTION
We shouldn't add protocols to the JGroups stack used by Infinispan.

Instead, we should use a ForkChannel,
so that counter and lock message do not interfere with Infinispan messages.