### PR TITLE
Changed usage of template to default cache to prevent template

### DIFF
--- a/src/main/java/io/vertx/ext/cluster/infinispan/InfinispanClusterManager.java
+++ b/src/main/java/io/vertx/ext/cluster/infinispan/InfinispanClusterManager.java
@@ -69,8 +69,6 @@ import static java.util.stream.Collectors.*;
 public class InfinispanClusterManager implements ClusterManager {
   private static final Logger log = LoggerFactory.getLogger(InfinispanClusterManager.class);
 
-  private static final String CONFIG_TEMPLATE = "__vertx.distributed.cache.config";
-
   private final String configPath;
 
   private Vertx vertx;
@@ -106,7 +104,7 @@ public class InfinispanClusterManager implements ClusterManager {
   @Override
   public <K, V> void getAsyncMultiMap(String name, Handler<AsyncResult<AsyncMultiMap<K, V>>> resultHandler) {
     vertx.executeBlocking(future -> {
-      Cache<MultiMapKey, Object> cache = cacheManager.getCache(name, CONFIG_TEMPLATE);
+      Cache<MultiMapKey, Object> cache = cacheManager.getCache(name);
       InfinispanAsyncMultiMap<K, V> asyncMultiMap = new InfinispanAsyncMultiMap<>(vertx, cache);
       synchronized (this) {
         multimaps.add(asyncMultiMap);
@@ -118,14 +116,14 @@ public class InfinispanClusterManager implements ClusterManager {
   @Override
   public <K, V> void getAsyncMap(String name, Handler<AsyncResult<AsyncMap<K, V>>> resultHandler) {
     vertx.executeBlocking(future -> {
-      Cache<Object, Object> cache = cacheManager.getCache(name, CONFIG_TEMPLATE);
+      Cache<Object, Object> cache = cacheManager.getCache(name);
       future.complete(new InfinispanAsyncMap<>(vertx, cache));
     }, false, resultHandler);
   }
 
   @Override
   public <K, V> Map<K, V> getSyncMap(String name) {
-    return cacheManager.getCache(name, CONFIG_TEMPLATE);
+    return cacheManager.getCache(name);
   }
 
   @Override

--- a/src/main/resources/infinispan.xml
+++ b/src/main/resources/infinispan.xml
@@ -23,7 +23,7 @@
     <stack-file name="jgroups" path="jgroups.xml"/>
   </jgroups>
 
-  <cache-container>
+  <cache-container default-cache="__vertx.distributed.cache">
 
     <transport stack="jgroups"/>
 
@@ -35,9 +35,9 @@
       <expiration interval="-1"/>
     </replicated-cache>
 
-    <distributed-cache-configuration name="__vertx.distributed.cache.config">
+    <distributed-cache name="__vertx.distributed.cache">
       <expiration interval="-1"/>
-    </distributed-cache-configuration>
+    </distributed-cache>
 
   </cache-container>
 

--- a/src/test/resources/infinispan-test.xml
+++ b/src/test/resources/infinispan-test.xml
@@ -23,7 +23,7 @@
     <stack-file name="jgroups" path="jgroups-test.xml"/>
   </jgroups>
 
-  <cache-container>
+  <cache-container default-cache="__vertx.distributed.cache">
 
     <transport stack="jgroups"/>
 
@@ -37,9 +37,9 @@
       <expiration interval="-1"/>
     </replicated-cache>
 
-    <distributed-cache-configuration name="__vertx.distributed.cache.config">
+    <distributed-cache name="__vertx.distributed.cache">
       <expiration interval="-1"/>
-    </distributed-cache-configuration>
+    </distributed-cache>
 
   </cache-container>
 


### PR DESCRIPTION
from overriding defined caches

* Caused ha cache to be distributed instead of repl
** Could cause test to fail if nodes were shut down too quickly