### PR TITLE
Data loss after rolling update

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -104,16 +104,11 @@ Notice that the custom Infinispan instance need to be configured with:
 
 [source,xml]
 ----
-<cache-container default-cache="__vertx.distributed.cache">
-
-  <replicated-cache name="__vertx.haInfo">
-    <expiration interval="-1"/>
-  </replicated-cache>
-
-  <distributed-cache name="__vertx.distributed.cache">
-    <expiration interval="-1"/>
-  </distributed-cache>
-
+<cache-container default-cache="distributed-cache">
+  <distributed-cache name="distributed-cache"/>
+  <distributed-cache name="__vertx.subs"/>
+  <replicated-cache name="__vertx.haInfo"/>
+  <distributed-cache-configuration name="__vertx.distributed.cache.configuration"/>
 </cache-container>
 ----
 

--- a/src/main/java/io/vertx/ext/cluster/infinispan/InfinispanClusterManager.java
+++ b/src/main/java/io/vertx/ext/cluster/infinispan/InfinispanClusterManager.java
@@ -47,6 +47,7 @@ import org.infinispan.lock.EmbeddedClusteredLockManagerFactory;
 import org.infinispan.lock.api.ClusteredLock;
 import org.infinispan.lock.impl.manager.EmbeddedClusteredLockManager;
 import org.infinispan.manager.DefaultCacheManager;
+import org.infinispan.manager.EmbeddedCacheManagerAdmin;
 import org.infinispan.multimap.api.embedded.EmbeddedMultimapCacheManagerFactory;
 import org.infinispan.multimap.impl.EmbeddedMultimapCache;
 import org.infinispan.multimap.impl.EmbeddedMultimapCacheManager;
@@ -145,7 +146,8 @@ public class InfinispanClusterManager implements ClusterManager {
   @Override
   public <K, V> void getAsyncMap(String name, Handler<AsyncResult<AsyncMap<K, V>>> resultHandler) {
     vertx.executeBlocking(future -> {
-      Cache<Object, Object> cache = cacheManager.getCache(name);
+      EmbeddedCacheManagerAdmin administration = cacheManager.administration();
+      Cache<Object, Object> cache = administration.getOrCreateCache(name, "__vertx.distributed.cache.configuration");
       future.complete(new InfinispanAsyncMapImpl<>(vertx, cache));
     }, false, resultHandler);
   }

--- a/src/main/resources/default-infinispan.xml
+++ b/src/main/resources/default-infinispan.xml
@@ -23,18 +23,12 @@
     <stack-file name="jgroups" path="default-configs/default-jgroups-tcp.xml"/>
   </jgroups>
 
-  <cache-container default-cache="__vertx.distributed.cache">
-
+  <cache-container default-cache="distributed-cache">
     <transport stack="jgroups"/>
-
-    <replicated-cache name="__vertx.haInfo">
-      <expiration interval="-1"/>
-    </replicated-cache>
-
-    <distributed-cache name="__vertx.distributed.cache">
-      <expiration interval="-1"/>
-    </distributed-cache>
-
+    <distributed-cache name="distributed-cache"/>
+    <distributed-cache name="__vertx.subs"/>
+    <replicated-cache name="__vertx.haInfo"/>
+    <distributed-cache-configuration name="__vertx.distributed.cache.configuration"/>
   </cache-container>
 
 </infinispan>


### PR DESCRIPTION
Fixes #45

ISPN 9.2 introduced a cache administration API.
It allows to get or create a new cache on *all* nodes.