### PR TITLE
Infinispan 9.4.10.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
   <properties>
     <stack.version>3.7.0-SNAPSHOT</stack.version>
     <asciidoc.dir>${project.basedir}/src/main/asciidoc</asciidoc.dir>
-    <infinispan.version>9.4.0.Final</infinispan.version>
+    <infinispan.version>9.4.10.Final</infinispan.version>
     <jgroups.kubernetes.version>1.0.7.Final</jgroups.kubernetes.version>
   </properties>
 


### PR DESCRIPTION
@tsegismont there was a bug in the latest version concerning the default behavior of clustered locks. this version fixed this, so there is nothing else to do more than upgrading the version. However, your requirements are there: clustered locks container is customizable for split brain and zero-capacity node.