### PR TITLE
Bump Caffeine to 2.8.0 for vertx-stack compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
     <dependency>
       <groupId>com.github.ben-manes.caffeine</groupId>
       <artifactId>caffeine</artifactId>
-      <version>2.6.2</version>
+      <version>2.8.0</version>
     </dependency>
     <dependency>
       <groupId>org.infinispan</groupId>


### PR DESCRIPTION
Currently there's a conflict between `io.vertx:vertx-infinispan:jar:sources:4.0.0-SNAPSHOT` and `io.vertx:vertx-camel-bridge:zip:docs:4.0.0-SNAPSHOT` that fail https://github.com/vert-x3/vertx-stack tests.