### PR TITLE
Perf improvements in subscription event handling

### DIFF
--- a/src/main/java/io/vertx/ext/cluster/infinispan/InfinispanClusterManager.java
+++ b/src/main/java/io/vertx/ext/cluster/infinispan/InfinispanClusterManager.java
@@ -267,7 +267,7 @@ public class InfinispanClusterManager implements ClusterManager {
       cacheManager.addListener(viewListener);
       try {
 
-        subsCacheHelper = new SubsCacheHelper(cacheManager, nodeSelector);
+        subsCacheHelper = new SubsCacheHelper(vertx, cacheManager, nodeSelector);
 
         nodeInfoCache = cacheManager.<String, byte[]>getCache("__vertx.nodeInfo").getAdvancedCache();
 

--- a/src/main/java/io/vertx/ext/cluster/infinispan/impl/SubsCacheHelper.java
+++ b/src/main/java/io/vertx/ext/cluster/infinispan/impl/SubsCacheHelper.java
@@ -112,14 +112,16 @@ public class SubsCacheHelper {
   }
 
   private void fireRegistrationUpdateEvent(String address) {
-    get(address).whenComplete((registrationInfos, throwable) -> {
-      if (throwable == null) {
-        nodeSelector.registrationsUpdated(new RegistrationUpdateEvent(address, registrationInfos));
-      } else {
-        log.trace("A failure occured while retrieving the updated registrations", throwable);
-        nodeSelector.registrationsUpdated(new RegistrationUpdateEvent(address, Collections.emptyList()));
-      }
-    });
+    if (nodeSelector.wantsUpdatesFor(address)) {
+      get(address).whenComplete((registrationInfos, throwable) -> {
+        if (throwable == null) {
+          nodeSelector.registrationsUpdated(new RegistrationUpdateEvent(address, registrationInfos));
+        } else {
+          log.trace("A failure occured while retrieving the updated registrations", throwable);
+          nodeSelector.registrationsUpdated(new RegistrationUpdateEvent(address, Collections.emptyList()));
+        }
+      });
+    }
   }
 
   @Listener(clustered = true, observation = POST, sync = false)

--- a/src/main/java/io/vertx/ext/cluster/infinispan/impl/Throttling.java
+++ b/src/main/java/io/vertx/ext/cluster/infinispan/impl/Throttling.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2021 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.vertx.ext.cluster.infinispan.impl;
+
+import io.vertx.core.impl.VertxInternal;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.Function;
+
+public class Throttling {
+
+  // @formatter:off
+  private enum State {
+    NEW {
+      State pending() { return PENDING; }
+      State start() { return RUNNING; }
+      State done() { throw new IllegalStateException(); }
+      State next() { throw new IllegalStateException(); }
+    },
+    PENDING {
+      State pending() { return this; }
+      State start() { return RUNNING; }
+      State done() { throw new IllegalStateException(); }
+      State next() { throw new IllegalStateException(); }
+    },
+    RUNNING {
+      State pending() { return RUNNING_PENDING; }
+      State start() { throw new IllegalStateException(); }
+      State done() { return FINISHED; }
+      State next() { throw new IllegalStateException(); }
+    },
+    RUNNING_PENDING {
+      State pending() { return this; }
+      State start() { throw new IllegalStateException(); }
+      State done() { return FINISHED_PENDING; }
+      State next() { throw new IllegalStateException(); }
+    },
+    FINISHED {
+      State pending() { return FINISHED_PENDING; }
+      State start() { throw new IllegalStateException(); }
+      State done() { throw new IllegalStateException(); }
+      State next() { return null; }
+    },
+    FINISHED_PENDING {
+      State pending() { return this; }
+      State start() { throw new IllegalStateException(); }
+      State done() { throw new IllegalStateException(); }
+      State next() { return NEW; }
+    };
+
+    abstract State pending();
+    abstract State start();
+    abstract State done();
+    abstract State next();
+  }
+  // @formatter:on
+
+  private final VertxInternal vertx;
+  private final Function<String, CompletableFuture<?>> action;
+  private final ConcurrentMap<String, State> map;
+
+  public Throttling(VertxInternal vertx, Function<String, CompletableFuture<?>> action) {
+    this.vertx = vertx;
+    this.action = action;
+    map = new ConcurrentHashMap<>();
+  }
+
+  public void onEvent(String address) {
+    State curr = map.compute(address, (s, state) -> state == null ? State.NEW : state.pending());
+    if (curr == State.NEW) {
+      run(address);
+    }
+  }
+
+  private void run(String address) {
+    map.computeIfPresent(address, (s, state) -> state.start());
+    action.apply(address).whenComplete((v, throwable) -> {
+      map.computeIfPresent(address, (s, state) -> state.done());
+      vertx.setTimer(20, l -> {
+        checkState(address);
+      });
+    });
+  }
+
+  private void checkState(String address) {
+    State curr = map.computeIfPresent(address, (s, state) -> state.next());
+    if (curr == State.NEW) {
+      run(address);
+    }
+  }
+}

--- a/src/test/java/io/vertx/ext/cluster/infinispan/impl/ThrottlingTest.java
+++ b/src/test/java/io/vertx/ext/cluster/infinispan/impl/ThrottlingTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2021 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.vertx.ext.cluster.infinispan.impl;
+
+import io.vertx.core.impl.VertxInternal;
+import io.vertx.test.core.VertxTestBase;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.*;
+
+import static java.util.concurrent.TimeUnit.*;
+
+public class ThrottlingTest extends VertxTestBase {
+
+  int threadCount = 4;
+  ExecutorService executorService;
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    executorService = Executors.newFixedThreadPool(threadCount);
+  }
+
+  @Test
+  public void testInterval() throws Exception {
+    int duration = 5;
+    String[] addresses = {"foo", "bar", "baz", "qux"};
+
+    ConcurrentMap<String, List<Long>> events = new ConcurrentHashMap<>(addresses.length);
+    Throttling throttling = new Throttling((VertxInternal) vertx, address -> {
+      events.compute(address, (k, v) -> {
+        if (v == null) {
+          v = Collections.synchronizedList(new LinkedList<>());
+        }
+        v.add(System.nanoTime());
+        return v;
+      });
+      CompletableFuture<Void> future = new CompletableFuture<>();
+      vertx.setTimer(1, l -> future.complete(null));
+      return future;
+    });
+
+    CountDownLatch latch = new CountDownLatch(threadCount);
+    long start = System.nanoTime();
+    for (int i = 0; i < threadCount; i++) {
+      executorService.submit(() -> {
+        try {
+          do {
+            sleepMax(5);
+            throttling.onEvent(addresses[ThreadLocalRandom.current().nextInt(addresses.length)]);
+          } while (SECONDS.convert(System.nanoTime() - start, NANOSECONDS) < duration);
+        } finally {
+          latch.countDown();
+        }
+      });
+    }
+    latch.await();
+
+    assertWaitUntil(() -> {
+      if (events.size() != addresses.length) {
+        return false;
+      }
+      for (List<Long> nanoTimes : events.values()) {
+        Long previous = null;
+        for (Long nanoTime : nanoTimes) {
+          if (previous != null) {
+            if (MILLISECONDS.convert(nanoTime - previous, NANOSECONDS) < 20) {
+              return false;
+            }
+          }
+          previous = nanoTime;
+        }
+      }
+      return true;
+    }, 1000);
+  }
+
+  private void sleepMax(long time) {
+    try {
+      MILLISECONDS.sleep(ThreadLocalRandom.current().nextLong(time));
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  @Override
+  protected void tearDown() throws Exception {
+    executorService.shutdown();
+    assertTrue(executorService.awaitTermination(5, SECONDS));
+    super.tearDown();
+  }
+}


### PR DESCRIPTION
Follows-up on eclipse-vertx/vert.x#3843 and eclipse-vertx/vert.x#3846

The improvements consist in:

- keeping local consumers data on the node
This reduces the traffic and prevents for notifying other nodes (which are not interested anyway).

- throttling subs lookups
This reduces traffic and load on all nodes

- making sure NodeSelector wants update before sending a backend query
This can help reduce load/traffic when a node is not sending messages to an address that gets subscription updates.