### PR TITLE
feat: update infinispan version to 14.0.13.Final

### DIFF
--- a/.github/workflows/ci-4.x.yml
+++ b/.github/workflows/ci-4.x.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        jdk: [8]
+        jdk: [11]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
@@ -47,7 +47,7 @@ jobs:
       - name: Install JDK
         uses: actions/setup-java@v2
         with:
-          java-version: 8
+          java-version: 11
           distribution: temurin
       - name: Get project version
         run: echo "PROJECT_VERSION=$(mvn org.apache.maven.plugins:maven-help-plugin:evaluate -Dexpression=project.version -B | grep -v '\[')" >> $GITHUB_ENV

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <stack.version>4.4.5-SNAPSHOT</stack.version>
     <doc.skip>true</doc.skip>
     <rxjava3.version>3.0.13</rxjava3.version>
-    <infinispan.version>13.0.17.Final</infinispan.version>
+    <infinispan.version>14.0.13.Final</infinispan.version>
   </properties>
 
   <dependencyManagement>

--- a/vertx-infinispan/src/main/resources/default-infinispan.xml
+++ b/vertx-infinispan/src/main/resources/default-infinispan.xml
@@ -16,11 +16,11 @@
   -->
 
 <infinispan xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xsi:schemaLocation="urn:infinispan:config:13.0 http://www.infinispan.org/schemas/infinispan-config-13.0.xsd"
-            xmlns="urn:infinispan:config:13.0">
+            xsi:schemaLocation="urn:infinispan:config:14.0 http://www.infinispan.org/schemas/infinispan-config-14.0.xsd"
+            xmlns="urn:infinispan:config:14.0">
 
   <jgroups>
-    <stack-file name="jgroups" path="default-configs/default-jgroups-tcp.xml"/>
+    <stack-file name="jgroups" path="tcp.xml"/>
   </jgroups>
 
   <cache-container default-cache="distributed-cache">

--- a/vertx-infinispan/src/test/resources/jgroups.xml
+++ b/vertx-infinispan/src/test/resources/jgroups.xml
@@ -16,11 +16,10 @@
 
 <config xmlns="urn:org:jgroups"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-4.2.xsd">
+        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-5.2.xsd">
   <!-- jgroups.tcp.address is deprecated and will be removed, see ISPN-11867 -->
   <TCP bind_addr="${jgroups.bind.address,jgroups.tcp.address:SITE_LOCAL}"
        bind_port="${jgroups.bind.port,jgroups.tcp.port:7800}"
-       enable_diagnostics="false"
        thread_naming_pattern="pl"
        send_buf_size="640k"
        sock_conn_timeout="300"
@@ -29,8 +28,6 @@
        thread_pool.min_threads="${jgroups.thread_pool.min_threads:0}"
        thread_pool.max_threads="${jgroups.thread_pool.max_threads:200}"
        thread_pool.keep_alive_time="60000"
-
-       thread_dumps_threshold="${jgroups.thread_dumps_threshold:10000}"
   />
   <FILE_PING location="${jgroups.file.location}"
              register_shutdown_hook="false"

--- a/vertx-web-sstore-infinispan/pom.xml
+++ b/vertx-web-sstore-infinispan/pom.xml
@@ -128,7 +128,7 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers</artifactId>
-      <version>1.15.2</version>
+      <version>1.18.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
This PR also updates the version of org.testcontainers, because the old one had a CVE.