### PR TITLE
Set io.smallrye.common:smallrye-common-annotation version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
     <caffeine.version>3.2.4</caffeine.version>
     <infinispan.version>16.2.1</infinispan.version>
     <wildfly-common.version>1.7.0.Final</wildfly-common.version>
+    <smallrye-common-annotation>2.14.0</smallrye-common-annotation>
   </properties>
 
   <dependencyManagement>

--- a/vertx-infinispan/pom.xml
+++ b/vertx-infinispan/pom.xml
@@ -56,6 +56,11 @@
       <artifactId>wildfly-common</artifactId>
       <version>${wildfly-common.version}</version>
     </dependency>
+    <dependency>
+      <groupId>io.smallrye.common</groupId>
+      <artifactId>smallrye-common-annotation</artifactId>
+      <version>${smallrye-common-annotation}</version>
+    </dependency>
 
     <dependency>
       <groupId>io.vertx</groupId>

--- a/vertx-web-sstore-infinispan/pom.xml
+++ b/vertx-web-sstore-infinispan/pom.xml
@@ -59,6 +59,11 @@
       <artifactId>wildfly-common</artifactId>
       <version>${wildfly-common.version}</version>
     </dependency>
+    <dependency>
+      <groupId>io.smallrye.common</groupId>
+      <artifactId>smallrye-common-annotation</artifactId>
+      <version>${smallrye-common-annotation}</version>
+    </dependency>
 
     <dependency>
       <groupId>io.vertx</groupId>


### PR DESCRIPTION
For dependency convergence, use a single version set in parent